### PR TITLE
lsコマンド(-aオプション)のプログラムを新規作成

### DIFF
--- a/05.ls/ls-a.rb
+++ b/05.ls/ls-a.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'optparse'
+
+MAX_COLUMNS = 3
+MAX_FILENAME_LENGTH = 24
+
+def main
+  options = retrieve_options
+  files = retrieve_files(options)
+  number_of_columns = calculate_columns
+  number_of_rows = calculate_rows(files, number_of_columns)
+  display(files, number_of_rows, number_of_columns)
+end
+
+def retrieve_options
+  ARGV.getopts('a')
+end
+
+def retrieve_files(options)
+  if options['a']
+    Dir.entries('.').sort
+  else
+    Dir.glob('*')
+  end
+end
+
+def calculate_columns
+  number_of_terminal_columns = `tput cols`.to_i
+  return MAX_COLUMNS if number_of_terminal_columns > MAX_FILENAME_LENGTH * MAX_COLUMNS
+
+  1.upto(MAX_COLUMNS) do |column|
+    break column if number_of_terminal_columns < MAX_FILENAME_LENGTH * (column + 1)
+  end
+end
+
+def calculate_rows(files, number_of_columns)
+  (files.count.to_f / number_of_columns).ceil(0)
+end
+
+def display(files, number_of_rows, number_of_columns)
+  number_of_rows.times do |row|
+    number_of_columns.times do |column|
+      index = number_of_rows * column + row
+      next unless files[index]
+
+      print files[index].ljust(MAX_FILENAME_LENGTH)
+    end
+    puts "\n"
+  end
+end
+
+main

--- a/05.ls/ls-a.rb
+++ b/05.ls/ls-a.rb
@@ -20,7 +20,7 @@ end
 
 def retrieve_files(options)
   if options['a']
-    Dir.entries('.').sort
+    Dir.glob('*', File::FNM_DOTMATCH)
   else
     Dir.glob('*')
   end


### PR DESCRIPTION
lsコマンド(-aオプション)のプログラムを新規作成致しましたのでレビューをお願いいたします。

オプション無しのlsコマンドとの主な差分としては、以下のメソッドの追加・修正になります。
・retrieve_optionsメソッド（追加）
・retrieve_files(options)メソッド（修正）